### PR TITLE
Campaign

### DIFF
--- a/lib/champions_of_mirra/accounts/user.ex
+++ b/lib/champions_of_mirra/accounts/user.ex
@@ -2,6 +2,8 @@ defmodule ChampionsOfMirra.Accounts.User do
   use ChampionsOfMirra.Schema
   import Ecto.Changeset
 
+  alias ChampionsOfMirra.Campaigns.Level
+  alias ChampionsOfMirra.Campaigns.LevelCompleted
   alias ChampionsOfMirra.Units.Unit
 
   schema "users" do
@@ -16,6 +18,8 @@ defmodule ChampionsOfMirra.Accounts.User do
     field(:experience, :float)
 
     has_many(:units, Unit)
+
+    many_to_many(:levels_completed, Level, join_through: LevelCompleted)
 
     timestamps()
   end

--- a/lib/champions_of_mirra/accounts/user.ex
+++ b/lib/champions_of_mirra/accounts/user.ex
@@ -2,6 +2,8 @@ defmodule ChampionsOfMirra.Accounts.User do
   use ChampionsOfMirra.Schema
   import Ecto.Changeset
 
+  alias ChampionsOfMirra.Campaigns.Campaign
+  alias ChampionsOfMirra.Campaigns.CampaignUnlocked
   alias ChampionsOfMirra.Campaigns.Level
   alias ChampionsOfMirra.Campaigns.LevelCompleted
   alias ChampionsOfMirra.Units.Unit
@@ -20,6 +22,7 @@ defmodule ChampionsOfMirra.Accounts.User do
     has_many(:units, Unit)
 
     many_to_many(:levels_completed, Level, join_through: LevelCompleted)
+    many_to_many(:unlocked_campaigns, Campaign, join_through: CampaignUnlocked)
 
     timestamps()
   end

--- a/lib/champions_of_mirra/accounts/user.ex
+++ b/lib/champions_of_mirra/accounts/user.ex
@@ -21,7 +21,7 @@ defmodule ChampionsOfMirra.Accounts.User do
 
     has_many(:units, Unit)
 
-    many_to_many(:levels_completed, Level, join_through: LevelCompleted)
+    many_to_many(:completed_levels, Level, join_through: LevelCompleted)
     many_to_many(:unlocked_campaigns, Campaign, join_through: CampaignUnlocked)
 
     timestamps()

--- a/lib/champions_of_mirra/autobattle.ex
+++ b/lib/champions_of_mirra/autobattle.ex
@@ -7,7 +7,7 @@ defmodule ChampionsOfMirra.Autobattle do
 
   Returns the id of the winner.
   """
-  def run_battle(user_1, user_2) do
+  def pvp_battle(user_1, user_2) do
     user_1_units = Units.get_selected_units(user_1)
     user_2_units = Units.get_selected_units(user_2)
 
@@ -19,11 +19,18 @@ defmodule ChampionsOfMirra.Autobattle do
         {:error, {:user_2, :no_selected_units}}
 
       true ->
-        user_1_agg_level = Enum.reduce(user_1_units, 0, fn unit, acc -> acc + unit.level end)
-        user_2_agg_level = Enum.reduce(user_2_units, 0, fn unit, acc -> acc + unit.level end)
-        total_level = user_1_agg_level + user_2_agg_level
-
-        if Enum.random(1..total_level) <= user_1_agg_level, do: user_1, else: user_2
+        case battle(user_1_units, user_2_units) do
+          :team_1 -> user_1
+          :team_2 -> user_2
+        end
     end
+  end
+
+  def battle(team_1, team_2) do
+    team_1_agg_level = Enum.reduce(team_1, 0, fn unit, acc -> unit.level + acc end)
+    team_2_agg_level = Enum.reduce(team_2, 0, fn unit, acc -> unit.level + acc end)
+    total_level = team_1_agg_level + team_2_agg_level
+
+    if Enum.random(1..total_level) <= team_1_agg_level, do: :team_1, else: :team_2
   end
 end

--- a/lib/champions_of_mirra/autobattle.ex
+++ b/lib/champions_of_mirra/autobattle.ex
@@ -1,9 +1,14 @@
 defmodule ChampionsOfMirra.Autobattle do
+  @moduledoc """
+  The Autobattle module focuses on simulating the fights between teams, wether they are PvE or PvP.
+
+  Fight outcomes are decided randomly, favoring the team with the higher aggregate level.
+  """
+
   alias ChampionsOfMirra.Units
 
   @doc """
-  Run an automatic battle between two users. The outcome is decided randomly, favoring the player
-  with the higher aggregate level of their selected units. Only validation done is for empty teams.
+  Run an automatic battle between two users. Only validation done is for empty teams.
 
   Returns the id of the winner.
   """
@@ -26,6 +31,10 @@ defmodule ChampionsOfMirra.Autobattle do
     end
   end
 
+  @doc """
+  Run a battle between two teams. The outcome is decided randomly, favoring the team
+  with the higher aggregate level of their selected units. Returns `:team_1` or `:team_2`.
+  """
   def battle(team_1, team_2) do
     team_1_agg_level = Enum.reduce(team_1, 0, fn unit, acc -> unit.level + acc end)
     team_2_agg_level = Enum.reduce(team_2, 0, fn unit, acc -> unit.level + acc end)

--- a/lib/champions_of_mirra/campaigns.ex
+++ b/lib/champions_of_mirra/campaigns.ex
@@ -15,13 +15,13 @@ defmodule ChampionsOfMirra.Campaigns do
   # Campaigns #
   #############
 
-  def insert_campaign(attrs \\ %{}) do
+  def insert_campaign(attrs) do
     %Campaign{}
     |> Campaign.changeset(attrs)
     |> Repo.insert()
   end
 
-  def get_campaign(id), do: Repo.get(Campaign, id)
+  def get_campaign(id), do: Repo.get(Campaign, id) |> Repo.preload(:levels)
 
   def get_campaigns(), do: Repo.all(Campaign)
 
@@ -31,7 +31,7 @@ defmodule ChampionsOfMirra.Campaigns do
   # Levels #
   ##########
 
-  def insert_level(attrs \\ %{}) do
+  def insert_level(attrs) do
     %Level{}
     |> Level.changeset(attrs)
     |> Repo.insert()
@@ -49,7 +49,7 @@ defmodule ChampionsOfMirra.Campaigns do
   # CampaignUnlocked #
   ####################
 
-  def insert_campaign_unlocked(attrs \\ %{}) do
+  def insert_campaign_unlocked(attrs) do
     %CampaignUnlocked{}
     |> CampaignUnlocked.changeset(attrs)
     |> Repo.insert()
@@ -59,11 +59,14 @@ defmodule ChampionsOfMirra.Campaigns do
   # LevelCompleted #
   ##################
 
-  def insert_level_completed(attrs \\ %{}) do
+  def insert_level_completed(attrs) do
     %LevelCompleted{}
     |> LevelCompleted.changeset(attrs)
     |> Repo.insert()
   end
+
+  def user_completed_level?(user_id, level_id),
+    do: Repo.exists?(from(lc in LevelCompleted, where: lc.user_id == ^user_id and lc.level_id == ^level_id))
 
   @doc """
   Returns the percentage of progress a user has accomplished on a campaign.

--- a/lib/champions_of_mirra/campaigns.ex
+++ b/lib/champions_of_mirra/campaigns.ex
@@ -15,40 +15,70 @@ defmodule ChampionsOfMirra.Campaigns do
   # Campaigns #
   #############
 
+  @doc """
+  Insert a campaign into the database.
+  """
   def insert_campaign(attrs) do
     %Campaign{}
     |> Campaign.changeset(attrs)
     |> Repo.insert()
   end
 
-  def get_campaign(id), do: Repo.get(Campaign, id) |> Repo.preload(:levels)
-
+  @doc """
+  Get all campaigns.
+  """
   def get_campaigns(), do: Repo.all(Campaign)
 
+  @doc """
+  Get a campaign by ID.
+  """
+  def get_campaign(id), do: Repo.get(Campaign, id) |> Repo.preload(:levels)
+
+  @doc """
+  Get a campaign by name.
+  """
   def get_campaign_by_name(name), do: Repo.one(from(c in Campaign, where: c.name == ^name))
 
   ##########
   # Levels #
   ##########
 
+  @doc """
+  Insert a level into the database.
+  """
   def insert_level(attrs) do
     %Level{}
     |> Level.changeset(attrs)
     |> Repo.insert()
   end
 
-  def get_level(id), do: Repo.get(Level, id) |> Repo.preload(units: :character)
-
+  @doc """
+  Get all levels.
+  """
   def get_levels(), do: Repo.all(Level)
 
+  @doc """
+  Get all levels for a specific campaign.
+  """
   def get_levels(campaign_id), do: Repo.all(from(l in Level, where: l.campaign_id == ^campaign_id))
 
+  @doc """
+  Get a level by ID.
+  """
+  def get_level(id), do: Repo.get(Level, id) |> Repo.preload(units: :character)
+
+  @doc """
+  Get a level by name.
+  """
   def get_level_by_name(name), do: Repo.one(from(l in Level, where: l.name == ^name))
 
   ####################
   # CampaignUnlocked #
   ####################
 
+  @doc """
+  Insert a record for unlocked campaigns.
+  """
   def insert_campaign_unlocked(attrs) do
     %CampaignUnlocked{}
     |> CampaignUnlocked.changeset(attrs)
@@ -59,12 +89,18 @@ defmodule ChampionsOfMirra.Campaigns do
   # LevelCompleted #
   ##################
 
+  @doc """
+  Insert a record for completed levels.
+  """
   def insert_level_completed(attrs) do
     %LevelCompleted{}
     |> LevelCompleted.changeset(attrs)
     |> Repo.insert()
   end
 
+  @doc """
+  Check if a user has completed a specific level.
+  """
   def user_completed_level?(user_id, level_id),
     do: Repo.exists?(from(lc in LevelCompleted, where: lc.user_id == ^user_id and lc.level_id == ^level_id))
 

--- a/lib/champions_of_mirra/campaigns.ex
+++ b/lib/champions_of_mirra/campaigns.ex
@@ -6,7 +6,9 @@ defmodule ChampionsOfMirra.Campaigns do
   import Ecto.Query
 
   alias ChampionsOfMirra.Campaigns.Campaign
+  alias ChampionsOfMirra.Campaigns.CampaignUnlocked
   alias ChampionsOfMirra.Campaigns.Level
+  alias ChampionsOfMirra.Campaigns.LevelCompleted
   alias ChampionsOfMirra.Repo
 
   #############
@@ -42,4 +44,24 @@ defmodule ChampionsOfMirra.Campaigns do
   def get_levels(campaign_id), do: Repo.all(from(l in Level, where: l.campaign_id == ^campaign_id))
 
   def get_level_by_name(name), do: Repo.one(from(l in Level, where: l.name == ^name))
+
+  ####################
+  # CampaignUnlocked #
+  ####################
+
+  def insert_campaign_unlocked(attrs \\ %{}) do
+    %CampaignUnlocked{}
+    |> CampaignUnlocked.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  ##################
+  # LevelCompleted #
+  ##################
+
+  def insert_level_completed(attrs \\ %{}) do
+    %LevelCompleted{}
+    |> LevelCompleted.changeset(attrs)
+    |> Repo.insert()
+  end
 end

--- a/lib/champions_of_mirra/campaigns.ex
+++ b/lib/champions_of_mirra/campaigns.ex
@@ -37,7 +37,7 @@ defmodule ChampionsOfMirra.Campaigns do
     |> Repo.insert()
   end
 
-  def get_level(id), do: Repo.get(Level, id)
+  def get_level(id), do: Repo.get(Level, id) |> Repo.preload(units: :character)
 
   def get_levels(), do: Repo.all(Level)
 

--- a/lib/champions_of_mirra/campaigns.ex
+++ b/lib/champions_of_mirra/campaigns.ex
@@ -64,4 +64,13 @@ defmodule ChampionsOfMirra.Campaigns do
     |> LevelCompleted.changeset(attrs)
     |> Repo.insert()
   end
+
+  @doc """
+  Returns the percentage of progress a user has accomplished on a campaign.
+  """
+  def user_progress(user, campaign) do
+    levels = campaign.levels
+    completed_levels = Repo.all(from lc in LevelCompleted, where: lc.user_id == ^user.id)
+    100 * length(completed_levels) / length(levels)
+  end
 end

--- a/lib/champions_of_mirra/campaigns.ex
+++ b/lib/champions_of_mirra/campaigns.ex
@@ -70,7 +70,7 @@ defmodule ChampionsOfMirra.Campaigns do
   """
   def user_progress(user, campaign) do
     levels = campaign.levels
-    completed_levels = Repo.all(from lc in LevelCompleted, where: lc.user_id == ^user.id)
+    completed_levels = Repo.all(from(lc in LevelCompleted, where: lc.user_id == ^user.id))
     100 * length(completed_levels) / length(levels)
   end
 end

--- a/lib/champions_of_mirra/campaigns.ex
+++ b/lib/champions_of_mirra/campaigns.ex
@@ -1,0 +1,45 @@
+defmodule ChampionsOfMirra.Campaigns do
+  @moduledoc """
+  Operations involving campaigns.
+  """
+
+  import Ecto.Query
+
+  alias ChampionsOfMirra.Campaigns.Campaign
+  alias ChampionsOfMirra.Campaigns.Level
+  alias ChampionsOfMirra.Repo
+
+  #############
+  # Campaigns #
+  #############
+
+  def insert_campaign(attrs \\ %{}) do
+    %Campaign{}
+    |> Campaign.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def get_campaign(id), do: Repo.get(Campaign, id)
+
+  def get_campaigns(), do: Repo.all(Campaign)
+
+  def get_campaign_by_name(name), do: Repo.one(from(c in Campaign, where: c.name == ^name))
+
+  ##########
+  # Levels #
+  ##########
+
+  def insert_level(attrs \\ %{}) do
+    %Level{}
+    |> Level.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def get_level(id), do: Repo.get(Level, id)
+
+  def get_levels(), do: Repo.all(Level)
+
+  def get_levels(campaign_id), do: Repo.all(from(l in Level, where: l.campaign_id == ^campaign_id))
+
+  def get_level_by_name(name), do: Repo.one(from(l in Level, where: l.name == ^name))
+end

--- a/lib/champions_of_mirra/campaigns/campaign.ex
+++ b/lib/champions_of_mirra/campaigns/campaign.ex
@@ -1,0 +1,28 @@
+defmodule ChampionsOfMirra.Campaigns.Campaign do
+  @moduledoc """
+  Characters are the template on which players are based.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChampionsOfMirra.Campaigns.Level
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  schema "campaigns" do
+    field(:name, :string)
+    field(:number, :integer)
+
+    has_many(:levels, Level)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(character, attrs),
+    do:
+      character
+      |> cast(attrs, [:name, :number])
+      |> cast_assoc(:levels)
+      |> validate_required([:name])
+end

--- a/lib/champions_of_mirra/campaigns/campaign.ex
+++ b/lib/champions_of_mirra/campaigns/campaign.ex
@@ -1,6 +1,8 @@
 defmodule ChampionsOfMirra.Campaigns.Campaign do
   @moduledoc """
-  Characters are the template on which players are based.
+  Campaigns are sets of levels that users can unlock and play. They have an optional number field for ordering.
+
+  When a user unlocks a campaign, it is tracked by the intermediate CampaignUnlocked table.
   """
 
   use Ecto.Schema

--- a/lib/champions_of_mirra/campaigns/campaign_unlocked.ex
+++ b/lib/champions_of_mirra/campaigns/campaign_unlocked.ex
@@ -1,0 +1,27 @@
+defmodule ChampionsOfMirra.Campaigns.CampaignUnlocked do
+  @moduledoc """
+  The user-level association intermediate table.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChampionsOfMirra.Accounts.User
+  alias ChampionsOfMirra.Campaigns.Campaign
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "campaign_unlocked" do
+    belongs_to(:user, User)
+    belongs_to(:campaign, Campaign)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(campaign_unlocked, attrs) do
+    campaign_unlocked
+    |> cast(attrs, [:user_id, :campaign_id])
+    |> validate_required([:user_id, :campaign_id])
+  end
+end

--- a/lib/champions_of_mirra/campaigns/level.ex
+++ b/lib/champions_of_mirra/campaigns/level.ex
@@ -1,6 +1,8 @@
 defmodule ChampionsOfMirra.Campaigns.Level do
   @moduledoc """
-  Characters are the template on which players are based.
+  Levels belong to campaigns and are composed by a set of units. They have an unique name and an order that's unique by campaign.
+
+  When users beat levels, it is tracked by the intermediate LevelCompleted table.
   """
 
   use Ecto.Schema

--- a/lib/champions_of_mirra/campaigns/level.ex
+++ b/lib/champions_of_mirra/campaigns/level.ex
@@ -1,0 +1,32 @@
+defmodule ChampionsOfMirra.Campaigns.Level do
+  @moduledoc """
+  Characters are the template on which players are based.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChampionsOfMirra.Campaigns.Campaign
+  alias ChampionsOfMirra.Units.Unit
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "levels" do
+    field(:name, :string)
+    field(:number, :integer)
+
+    belongs_to(:campaign, Campaign)
+
+    has_many(:units, Unit, foreign_key: :campaign_level_id)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(character, attrs),
+    do:
+      character
+      |> cast(attrs, [:name, :number, :campaign_id])
+      |> cast_assoc(:units)
+      |> validate_required([:name, :number])
+end

--- a/lib/champions_of_mirra/campaigns/level_completed.ex
+++ b/lib/champions_of_mirra/campaigns/level_completed.ex
@@ -14,7 +14,6 @@ defmodule ChampionsOfMirra.Campaigns.LevelCompleted do
   schema "level_completed" do
     belongs_to(:user, User)
     belongs_to(:level, Level)
-    field(:rating, :integer)
 
     timestamps()
   end
@@ -22,7 +21,7 @@ defmodule ChampionsOfMirra.Campaigns.LevelCompleted do
   @doc false
   def changeset(level_completed, attrs) do
     level_completed
-    |> cast(attrs, [:user_id, :level_id, :rating])
-    |> validate_required([:user_id, :level_id, :rating])
+    |> cast(attrs, [:user_id, :level_id])
+    |> validate_required([:user_id, :level_id])
   end
 end

--- a/lib/champions_of_mirra/campaigns/level_completed.ex
+++ b/lib/champions_of_mirra/campaigns/level_completed.ex
@@ -1,0 +1,28 @@
+defmodule ChampionsOfMirra.Campaigns.LevelCompleted do
+  @moduledoc """
+  The user-level association intermediate table.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChampionsOfMirra.Accounts.User
+  alias ChampionsOfMirra.Campaigns.Level
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "level_completed" do
+    belongs_to(:user, User)
+    belongs_to(:level, Level)
+    field(:rating, :integer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(level_completed, attrs) do
+    level_completed
+    |> cast(attrs, [:user_id, :level_id, :rating])
+    |> validate_required([:user_id, :level_id, :rating])
+  end
+end

--- a/lib/champions_of_mirra/units/unit.ex
+++ b/lib/champions_of_mirra/units/unit.ex
@@ -7,6 +7,7 @@ defmodule ChampionsOfMirra.Units.Unit do
   import Ecto.Changeset
 
   alias ChampionsOfMirra.Accounts.User
+  alias ChampionsOfMirra.Campaigns.Level
   alias ChampionsOfMirra.Characters.Character
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -17,6 +18,8 @@ defmodule ChampionsOfMirra.Units.Unit do
     field(:slot, :integer)
 
     belongs_to(:user, User)
+    belongs_to(:campaign_level, Level, foreign_key: :campaign_level_id)
+
     belongs_to(:character, Character)
 
     timestamps()
@@ -26,7 +29,7 @@ defmodule ChampionsOfMirra.Units.Unit do
   def changeset(unit, attrs) do
     unit
     |> cast(attrs, [:level, :selected, :slot, :character_id, :user_id])
-    |> validate_required([:level, :selected, :character_id, :user_id])
+    |> validate_required([:level, :selected, :character_id])
   end
 
   @doc """

--- a/lib/champions_of_mirra_web/controllers/campaign_controller.ex
+++ b/lib/champions_of_mirra_web/controllers/campaign_controller.ex
@@ -23,9 +23,9 @@ defmodule ChampionsOfMirraWeb.CampaignController do
 
       user ->
         with %Campaign{} = campaign <- Campaigns.get_campaign(campaign_id),
-             campaign_map <- format_campaign(campaign, user) do
-          levels = campaign.levels |> Enum.map(&format_level(&1, user))
-          campaign_map = Map.put(campaign_map, :levels, levels)
+             campaign_map <- format_campaign(campaign, user),
+             levels <- Enum.map(campaign.levels, &format_level(&1, user)),
+             campaign_map <- Map.put(campaign_map, :levels, levels) do
           json(conn, campaign_map)
         else
           nil -> json(conn, %{error: "INEXISTENT_CAMPAIGN"})

--- a/lib/champions_of_mirra_web/controllers/campaign_controller.ex
+++ b/lib/champions_of_mirra_web/controllers/campaign_controller.ex
@@ -1,0 +1,21 @@
+defmodule ChampionsOfMirraWeb.CampaignController do
+  use ChampionsOfMirraWeb, :controller
+  alias ChampionsOfMirra.Accounts
+  alias ChampionsOfMirra.Campaigns
+  alias ChampionsOfMirra.Campaigns.Campaign
+  alias ChampionsOfMirra.Repo
+
+  def get_campaigns(conn, %{"device_client_id" => device_client_id}) do
+    case Accounts.get_user_by_device_client_id(device_client_id) |> Repo.preload(unlocked_campaigns: :levels) do
+      nil ->
+        json(conn, %{error: "INEXISTENT_USER"})
+
+      user ->
+        json(conn, Enum.map(user.unlocked_campaigns, &format_campaign(&1, user)))
+    end
+  end
+
+  defp format_campaign(%Campaign{name: name, number: number, id: id} = campaign, user) do
+    %{id: id, name: name, number: number, progress: Campaigns.user_progress(user, campaign)}
+  end
+end

--- a/lib/champions_of_mirra_web/controllers/campaign_controller.ex
+++ b/lib/champions_of_mirra_web/controllers/campaign_controller.ex
@@ -60,7 +60,10 @@ defmodule ChampionsOfMirraWeb.CampaignController do
       user ->
         with %Level{} = level <- Campaigns.get_level(level_id),
              winner <- Autobattle.battle(user.units, level.units) do
-          json(conn, winner == :team_1)
+          won = winner == :team_1
+          if won, do: Campaigns.insert_level_completed(%{user_id: user.id, level_id: level_id})
+
+          json(conn, won)
         else
           nil -> json(conn, %{error: "INEXISTENT_LEVEL"})
         end

--- a/lib/champions_of_mirra_web/controllers/pvp_controller.ex
+++ b/lib/champions_of_mirra_web/controllers/pvp_controller.ex
@@ -3,13 +3,13 @@ defmodule ChampionsOfMirraWeb.PvPController do
   alias ChampionsOfMirra.Accounts
   alias ChampionsOfMirra.Autobattle
 
-  def run_battle(conn, %{"device_client_id" => device_client_id, "target_user_id" => target_user_id}) do
+  def battle(conn, %{"device_client_id" => device_client_id, "target_user_id" => target_user_id}) do
     case Accounts.get_user_by_device_client_id(device_client_id) do
       nil ->
         json(conn, %{error: "INEXISTENT_USER"})
 
       user ->
-        winner = Autobattle.run_battle(user.id, target_user_id)
+        winner = Autobattle.pvp_battle(user.id, target_user_id)
 
         json(conn, %{winner: winner})
     end

--- a/lib/champions_of_mirra_web/controllers/pvp_controller.ex
+++ b/lib/champions_of_mirra_web/controllers/pvp_controller.ex
@@ -1,11 +1,9 @@
-defmodule ChampionsOfMirraWeb.AutobattleController do
+defmodule ChampionsOfMirraWeb.PvPController do
   use ChampionsOfMirraWeb, :controller
   alias ChampionsOfMirra.Accounts
   alias ChampionsOfMirra.Autobattle
 
   def run_battle(conn, %{"device_client_id" => device_client_id, "target_user_id" => target_user_id}) do
-    ChampionsOfMirra.Accounts.get_user_by_device_client_id(device_client_id)
-
     case Accounts.get_user_by_device_client_id(device_client_id) do
       nil ->
         json(conn, %{error: "INEXISTENT_USER"})

--- a/lib/champions_of_mirra_web/router.ex
+++ b/lib/champions_of_mirra_web/router.ex
@@ -34,9 +34,11 @@ defmodule ChampionsOfMirraWeb.Router do
       get "/get_opponents", UserController, :get_opponents
       get "/pvp/:target_user_id", PvPController, :battle
 
-      get "/campaigns/", CampaignController, :get_campaigns
-      get "/campaigns/:campaign_id", CampaignController, :get_campaign
-      get "/campaigns/:campaign_id/levels/:level_id", CampaignController, :battle_level
+      scope "/campaigns" do
+        get "/", CampaignController, :get_campaigns
+        get "/:campaign_id", CampaignController, :get_campaign
+        get "/:campaign_id/levels/:level_id", CampaignController, :battle_level
+      end
     end
   end
 

--- a/lib/champions_of_mirra_web/router.ex
+++ b/lib/champions_of_mirra_web/router.ex
@@ -32,7 +32,7 @@ defmodule ChampionsOfMirraWeb.Router do
 
     scope "/battle/:device_client_id/" do
       get "/get_opponents", UserController, :get_opponents
-      get "/pvp/:target_user_id", PvPController, :run_battle
+      get "/pvp/:target_user_id", PvPController, :battle
 
       get "/campaigns/", CampaignController, :get_campaigns
       get "/campaigns/:campaign_id", CampaignController, :get_campaign

--- a/lib/champions_of_mirra_web/router.ex
+++ b/lib/champions_of_mirra_web/router.ex
@@ -28,17 +28,20 @@ defmodule ChampionsOfMirraWeb.Router do
       get "/get_units/", UserController, :get_units
       put "/select_unit/:unit_id", UserController, :add_selected_unit
       put "/unselect_unit/:unit_id", UserController, :remove_selected_unit
-    end
 
-    scope "/battle/:device_client_id/" do
       get "/get_opponents", UserController, :get_opponents
-      get "/pvp/:target_user_id", PvPController, :battle
 
       scope "/campaigns" do
         get "/", CampaignController, :get_campaigns
         get "/:campaign_id", CampaignController, :get_campaign
-        get "/:campaign_id/levels/:level_id", CampaignController, :battle_level
+        get "/:campaign_id/levels/:level_id", CampaignController, :get_level
       end
+    end
+
+
+    scope "/battle/:device_client_id/" do
+      get "/pvp/:target_user_id", PvPController, :battle
+      get "/pve/:level_id", CampaignController, :battle
     end
   end
 

--- a/lib/champions_of_mirra_web/router.ex
+++ b/lib/champions_of_mirra_web/router.ex
@@ -24,13 +24,23 @@ defmodule ChampionsOfMirraWeb.Router do
     scope "/users/:device_client_id/" do
       get "/", UserController, :get_user
       put "/edit", UserController, :update_selected_character
+
       get "/get_units/", UserController, :get_units
-      get "/get_opponents", UserController, :get_opponents
       put "/select_unit/:unit_id", UserController, :add_selected_unit
       put "/unselect_unit/:unit_id", UserController, :remove_selected_unit
+
     end
 
-    get "/autobattle/:device_client_id/:target_user_id", AutobattleController, :run_battle
+
+    scope "/battle/:device_client_id/" do
+      get "/get_opponents", UserController, :get_opponents
+      get "/pvp/:target_user_id", PvPController, :run_battle
+
+      get "/campaigns/", CampaignController, :get_campaigns
+      get "/campaigns/:campaign_id", CampaignController, :get_campaign
+      get "/campaigns/:campaign_id/levels/:level_id", CampaignController, :battle_level
+    end
+
   end
 
   # Other scopes may use custom stacks.

--- a/lib/champions_of_mirra_web/router.ex
+++ b/lib/champions_of_mirra_web/router.ex
@@ -38,7 +38,6 @@ defmodule ChampionsOfMirraWeb.Router do
       end
     end
 
-
     scope "/battle/:device_client_id/" do
       get "/pvp/:target_user_id", PvPController, :battle
       get "/pve/:level_id", CampaignController, :battle

--- a/lib/champions_of_mirra_web/router.ex
+++ b/lib/champions_of_mirra_web/router.ex
@@ -30,7 +30,6 @@ defmodule ChampionsOfMirraWeb.Router do
     end
 
     get "/autobattle/:device_client_id/:target_user_id", AutobattleController, :run_battle
-
   end
 
   # Other scopes may use custom stacks.

--- a/lib/champions_of_mirra_web/router.ex
+++ b/lib/champions_of_mirra_web/router.ex
@@ -28,9 +28,7 @@ defmodule ChampionsOfMirraWeb.Router do
       get "/get_units/", UserController, :get_units
       put "/select_unit/:unit_id", UserController, :add_selected_unit
       put "/unselect_unit/:unit_id", UserController, :remove_selected_unit
-
     end
-
 
     scope "/battle/:device_client_id/" do
       get "/get_opponents", UserController, :get_opponents
@@ -40,7 +38,6 @@ defmodule ChampionsOfMirraWeb.Router do
       get "/campaigns/:campaign_id", CampaignController, :get_campaign
       get "/campaigns/:campaign_id/levels/:level_id", CampaignController, :battle_level
     end
-
   end
 
   # Other scopes may use custom stacks.

--- a/priv/repo/migrations/20240102182215_add_campaigns.exs
+++ b/priv/repo/migrations/20240102182215_add_campaigns.exs
@@ -8,6 +8,12 @@ defmodule ChampionsOfMirra.Repo.Migrations.AddCampaigns do
       timestamps()
     end
 
+    create table(:campaign_unlocked) do
+      add(:campaign_id, references(:campaigns), null: false)
+      add(:user_id, references(:users), null: false)
+      timestamps()
+    end
+
     create table(:levels) do
       add(:name, :string)
       add(:number, :integer)

--- a/priv/repo/migrations/20240102182215_add_campaigns.exs
+++ b/priv/repo/migrations/20240102182215_add_campaigns.exs
@@ -30,7 +30,6 @@ defmodule ChampionsOfMirra.Repo.Migrations.AddCampaigns do
     create table(:level_completed) do
       add(:level_id, references(:levels), null: false)
       add(:user_id, references(:users), null: false)
-      add(:rating, :integer)
       timestamps()
     end
 

--- a/priv/repo/migrations/20240102182215_add_campaigns.exs
+++ b/priv/repo/migrations/20240102182215_add_campaigns.exs
@@ -1,0 +1,36 @@
+defmodule ChampionsOfMirra.Repo.Migrations.AddCampaigns do
+  use Ecto.Migration
+
+  def change do
+    create table(:campaigns) do
+      add(:name, :string)
+      add(:number, :integer)
+      timestamps()
+    end
+
+    create table(:levels) do
+      add(:name, :string)
+      add(:number, :integer)
+      add(:campaign_id, references(:campaigns), null: false)
+      timestamps()
+    end
+
+    drop constraint(:units, "units_user_id_fkey")
+    alter table(:units) do
+      modify(:user_id, references(:users), null: true)
+      add(:campaign_level_id, references(:levels), null: true)
+    end
+
+    create table(:level_completed) do
+      add(:level_id, references(:levels), null: false)
+      add(:user_id, references(:users), null: false)
+      add(:rating, :string)
+      timestamps()
+    end
+
+    create unique_index(:campaigns, :name)
+    create unique_index(:campaigns, :number)
+    create unique_index(:levels, :name)
+    create unique_index(:levels, [:campaign_id, :number])
+  end
+end

--- a/priv/repo/migrations/20240102182215_add_campaigns.exs
+++ b/priv/repo/migrations/20240102182215_add_campaigns.exs
@@ -30,7 +30,7 @@ defmodule ChampionsOfMirra.Repo.Migrations.AddCampaigns do
     create table(:level_completed) do
       add(:level_id, references(:levels), null: false)
       add(:user_id, references(:users), null: false)
-      add(:rating, :string)
+      add(:rating, :integer)
       timestamps()
     end
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -71,7 +71,7 @@ characters =
 
 user_1_units =
   Enum.map(
-    1..6,
+    0..4,
     &Units.insert_unit(%{
       level: Enum.random(1..5),
       selected: true,
@@ -83,7 +83,7 @@ user_1_units =
 
 user_2_units =
   Enum.map(
-    1..6,
+    0..4,
     &Units.insert_unit(%{
       level: Enum.random(1..5),
       selected: true,

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -41,89 +41,82 @@ level_names = [
 
 ### Characters
 
-characters = Enum.map(character_names, fn name ->
-  {:ok, character} = Characters.insert_character(%{name: name})
-  character
-end)
+characters =
+  Enum.map(character_names, fn name ->
+    {:ok, character} = Characters.insert_character(%{name: name})
+    character
+  end)
+
 [muflus, h4ck, uma, valtimer, _otix, _kenzu, _uren, _dagna] = characters
 
 ### Users
 
 {:ok, user_1} =
-  Accounts.register_user(%{email: "faker@t1.com", username: "Faker", password: "fakerfakerfaker"})
+  Accounts.register_user(%{email: "user1@mail.com", username: "User1", password: "useruseruser"})
 
 {:ok, user_2} =
-  Accounts.register_user(%{email: "doinb@fpx.com", username: "Doinb", password: "doinbdoinbdoinb"})
+  Accounts.register_user(%{email: "user2@mail.com", username: "User2", password: "useruseruser"})
 
 ### Units
 
 ## User 1
+user_1_units =
+  Enum.map(
+    1..6,
+    &Units.insert_unit(%{
+      level: Enum.random(1..5),
+      selected: true,
+      slot: &1,
+      character_id: Enum.random(characters).id,
+      user_id: user_1.id
+    })
+  )
 
-{:ok, _} = Units.insert_unit(%{
-  level: 4,
-  selected: true,
-  slot: 1,
-  user_id: user_1.id,
-  character_id: muflus.id
-})
+user_2_units =
+  Enum.map(
+    1..6,
+    &Units.insert_unit(%{
+      level: Enum.random(1..5),
+      selected: true,
+      slot: &1,
+      character_id: Enum.random(characters).id,
+      user_id: user_2.id
+    })
+  )
 
-{:ok, _} = Units.insert_unit(%{
-  level: 3,
-  selected: true,
-  slot: 2,
-  user_id: user_1.id,
-  character_id: h4ck.id
-})
-
-{:ok, _} = Units.insert_unit(%{
-  level: 2,
-  selected: true,
-  slot: 3,
-  user_id: user_1.id,
-  character_id: uma.id
-})
-
-# User 2
-
-{:ok, _} = Units.insert_unit(%{
-  level: 1,
-  selected: true,
-  slot: 1,
-  user_id: user_2.id,
-  character_id: h4ck.id
-})
-
-{:ok, _} = Units.insert_unit(%{
-  level: 1,
-  selected: true,
-  slot: 2,
-  user_id: user_2.id,
-  character_id: valtimer.id
-})
-
-{:ok, _} = Units.insert_unit(%{
-  level: 2,
-  selected: true,
-  slot: 3,
-  user_id: user_2.id,
-  character_id: muflus.id
-})
+assert_units_insert_ok(user_1_units)
+assert_units_insert_ok(user_2_units)
 
 ### Campaigns
 
-{:ok, _campaign} = Campaigns.insert_campaign(%{
-  name: "Great Kaline War",
-  number: 1,
-  levels: level_names |> Enum.with_index() |> Enum.map(fn {name, number} ->
-    %{
-      name: name,
-      number: number,
-      units: Enum.map(1..5, & %{
-        level: Enum.random(min(1, number - 1)..number + 1),
-        selected: true,
-        slot: &1,
-        character_id: Enum.random(characters).id
-        })
-    }
+{:ok, _campaign} =
+  Campaigns.insert_campaign(%{
+    name: "Great Kaline War",
+    number: 1,
+    levels:
+      level_names
+      |> Enum.with_index()
+      |> Enum.map(fn {name, number} ->
+        %{
+          name: name,
+          number: number,
+          units:
+            Enum.map(
+              1..6,
+              &%{
+                level: Enum.random(min(1, number - 1)..(number + 1)),
+                selected: true,
+                slot: &1,
+                character_id: Enum.random(characters).id
+              }
+            )
+        }
+      end)
+  })
+
+def assert_units_insert_ok(units) do
+  Enum.all?(units, fn
+    {:ok, _unit} -> true
+    _ -> false
   end)
-})
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,60 +10,120 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-alias ChampionsOfMirra.Characters.Character
-alias ChampionsOfMirra.Repo
-Repo.insert!(Character.changeset(%Character{}, %{name: "muflus"}))
-Repo.insert!(Character.changeset(%Character{}, %{name: "h4ck"}))
-Repo.insert!(Character.changeset(%Character{}, %{name: "uma"}))
-Repo.insert!(Character.changeset(%Character{}, %{name: "valtimer"}))
-Repo.insert!(Character.changeset(%Character{}, %{name: "otix"}))
-Repo.insert!(Character.changeset(%Character{}, %{name: "kenzu"}))
-Repo.insert!(Character.changeset(%Character{}, %{name: "uren"}))
-Repo.insert!(Character.changeset(%Character{}, %{name: "d'agna"}))
+alias ChampionsOfMirra.Characters
+alias ChampionsOfMirra.Units
+alias ChampionsOfMirra.Campaigns
+alias ChampionsOfMirra.Accounts
 
-{:ok, user1} = ChampionsOfMirra.Accounts.register_user %{email: "faker@t1.com", username: "Faker", password: "fakerfakerfaker"}
-{:ok, user2} = ChampionsOfMirra.Accounts.register_user %{email: "doinb@fpx.com", username: "Doinb", password: "doinbdoinbdoinb"}
-user_1_id = user1.id
-user_2_id = user2.id
-ChampionsOfMirra.Units.insert_unit(%{
+character_names = [
+  "muflus",
+  "h4ck",
+  "uma",
+  "valtimer",
+  "otix",
+  "kenzu",
+  "uren",
+  "dagna"
+]
+
+level_names = [
+  "Shadows' Veil Confrontation",
+  "Enigma of the Cursed Mists",
+  "Infernal Eclipse Skirmish",
+  "Celestial Citadel Clash",
+  "Whispering Abyss Showdown",
+  "Radiant Fury Rampart",
+  "Vortex of Eternal Strife",
+  "Luminous Desolation Duel",
+  "Mystic Tides Turmoil",
+  "Abyssal Dominion Decisive"
+]
+
+### Characters
+
+characters = Enum.map(character_names, fn name ->
+  {:ok, character} = Characters.insert_character(%{name: name})
+  character
+end)
+[muflus, h4ck, uma, valtimer, _otix, _kenzu, _uren, _dagna] = characters
+
+### Users
+
+{:ok, user_1} =
+  Accounts.register_user(%{email: "faker@t1.com", username: "Faker", password: "fakerfakerfaker"})
+
+{:ok, user_2} =
+  Accounts.register_user(%{email: "doinb@fpx.com", username: "Doinb", password: "doinbdoinbdoinb"})
+
+### Units
+
+## User 1
+
+{:ok, _} = Units.insert_unit(%{
   level: 4,
   selected: true,
-  position: 1,
-  user_id: user_1_id,
-  character_id: ChampionsOfMirra.Characters.get_character_by_name("muflus").id
+  slot: 1,
+  user_id: user_1.id,
+  character_id: muflus.id
 })
-ChampionsOfMirra.Units.insert_unit(%{
+
+{:ok, _} = Units.insert_unit(%{
   level: 3,
   selected: true,
-  position: 2,
-  user_id: user_1_id,
-  character_id: ChampionsOfMirra.Characters.get_character_by_name("h4ck").id
+  slot: 2,
+  user_id: user_1.id,
+  character_id: h4ck.id
 })
-ChampionsOfMirra.Units.insert_unit(%{
+
+{:ok, _} = Units.insert_unit(%{
   level: 2,
   selected: true,
-  position: 3,
-  user_id: user_1_id,
-  character_id: ChampionsOfMirra.Characters.get_character_by_name("uma").id
+  slot: 3,
+  user_id: user_1.id,
+  character_id: uma.id
 })
-ChampionsOfMirra.Units.insert_unit(%{
+
+# User 2
+
+{:ok, _} = Units.insert_unit(%{
   level: 1,
   selected: true,
-  position: 1,
-  user_id: user_2_id,
-  character_id: ChampionsOfMirra.Characters.get_character_by_name("h4ck").id
+  slot: 1,
+  user_id: user_2.id,
+  character_id: h4ck.id
 })
-ChampionsOfMirra.Units.insert_unit(%{
+
+{:ok, _} = Units.insert_unit(%{
   level: 1,
   selected: true,
-  position: 2,
-  user_id: user_2_id,
-  character_id: ChampionsOfMirra.Characters.get_character_by_name("valtimer").id
+  slot: 2,
+  user_id: user_2.id,
+  character_id: valtimer.id
 })
-ChampionsOfMirra.Units.insert_unit(%{
+
+{:ok, _} = Units.insert_unit(%{
   level: 2,
   selected: true,
-  position: 3,
-  user_id: user_2_id,
-  character_id: ChampionsOfMirra.Characters.get_character_by_name("muflus").id
+  slot: 3,
+  user_id: user_2.id,
+  character_id: muflus.id
+})
+
+### Campaigns
+
+{:ok, _campaign} = Campaigns.insert_campaign(%{
+  name: "Great Kaline War",
+  number: 1,
+  levels: level_names |> Enum.with_index() |> Enum.map(fn {name, number} ->
+    %{
+      name: name,
+      number: number,
+      units: Enum.map(1..5, & %{
+        level: Enum.random(min(1, number - 1)..number + 1),
+        selected: true,
+        slot: &1,
+        character_id: Enum.random(characters).id
+        })
+    }
+  end)
 })

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -59,7 +59,6 @@ characters =
 
 ### Units
 
-## User 1
 user_1_units =
   Enum.map(
     1..6,

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -84,8 +84,15 @@ user_2_units =
     })
   )
 
-assert_units_insert_ok(user_1_units)
-assert_units_insert_ok(user_2_units)
+Enum.all?(user_1_units, fn
+  {:ok, _unit} -> true
+  _ -> false
+end)
+
+Enum.all?(user_2_units, fn
+  {:ok, _unit} -> true
+  _ -> false
+end)
 
 ### Campaigns
 
@@ -113,10 +120,3 @@ assert_units_insert_ok(user_2_units)
         }
       end)
   })
-
-def assert_units_insert_ok(units) do
-  Enum.all?(units, fn
-    {:ok, _unit} -> true
-    _ -> false
-  end)
-end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -52,10 +52,20 @@ characters =
 ### Users
 
 {:ok, user_1} =
-  Accounts.register_user(%{email: "user1@mail.com", username: "User1", password: "useruseruser"})
+  Accounts.register_user(%{
+    email: "user1@mail.com",
+    username: "user1",
+    password: "useruseruser",
+    device_client_id: "user1"
+  })
 
 {:ok, user_2} =
-  Accounts.register_user(%{email: "user2@mail.com", username: "User2", password: "useruseruser"})
+  Accounts.register_user(%{
+    email: "user2@mail.com",
+    username: "user2",
+    password: "useruseruser",
+    device_client_id: "user2"
+  })
 
 ### Units
 
@@ -95,7 +105,7 @@ end)
 
 ### Campaigns
 
-{:ok, _campaign} =
+{:ok, campaign} =
   Campaigns.insert_campaign(%{
     name: "Great Kaline War",
     number: 1,
@@ -119,3 +129,5 @@ end)
         }
       end)
   })
+
+{:ok, _} = Campaigns.insert_campaign_unlocked(%{user_id: user_1.id, campaign_id: campaign.id})

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -111,7 +111,7 @@ end)
     number: 1,
     levels:
       level_names
-      |> Enum.with_index()
+      |> Enum.with_index(1)
       |> Enum.map(fn {name, number} ->
         %{
           name: name,
@@ -131,3 +131,4 @@ end)
   })
 
 {:ok, _} = Campaigns.insert_campaign_unlocked(%{user_id: user_1.id, campaign_id: campaign.id})
+{:ok, _} = Campaigns.insert_level_completed(%{user_id: user_1.id, level_id: hd(campaign.levels).id, rating: 2})

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -120,7 +120,7 @@ end)
             Enum.map(
               1..6,
               &%{
-                level: Enum.random(min(1, number - 1)..(number + 1)),
+                level: Enum.random(max(1, number - 1)..(number + 1)),
                 selected: true,
                 slot: &1,
                 character_id: Enum.random(characters).id

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -131,4 +131,4 @@ end)
   })
 
 {:ok, _} = Campaigns.insert_campaign_unlocked(%{user_id: user_1.id, campaign_id: campaign.id})
-{:ok, _} = Campaigns.insert_level_completed(%{user_id: user_1.id, level_id: hd(campaign.levels).id, rating: 2})
+{:ok, _} = Campaigns.insert_level_completed(%{user_id: user_1.id, level_id: hd(campaign.levels).id})


### PR DESCRIPTION
Adds campaigns and pve to our game!

We now have campaigns and levels for which users have some progress on (levels can be completed or not; campaigns track progress in terms of % of levels completed, calculated when needed). Each level comes with its set of units that users can fight by calling the adequate endpoint. Beating the fight sets the level as completed for the user.

The seeds have been fixed and expanded a lot. Also the user battle endpoint has been renamed.

Here are some sample endpoint calls:

```
# Gets all campaigns available to a user & their progress on them
curl localhost:4000/users/user1/campaigns/

# Gets information of a campaign & its levels
curl localhost:4000/users/user1/campaigns/{campaign_id}

# Gets information of a level & its units
curl localhost:4000/users/user1/campaigns/{campaign_id}/levels/{level_id}

# Battle a level
curl localhost:4000/battle/user1/pve/{level_id}

# Battle a user (logic untouched, just the endpoint changed)
curl localhost:4000/battle/user1/pvp/{user_id}
```